### PR TITLE
Wangsets

### DIFF
--- a/TiledLib.Tests/Data/External_tileset.json
+++ b/TiledLib.Tests/Data/External_tileset.json
@@ -6,32 +6,9 @@
  "name":"External_Tileset",
  "spacing":0,
  "tilecount":1440,
+ "tiledversion":"1.2.2",
  "tileheight":16,
- "tileproperties":
-    {
-     "128":
-        {
-         "foo":"bar"
-        },
-     "168":
-        {
-         "foo":"bar"
-        }
-    },
- "tilepropertytypes":
-    {
-     "128":
-        {
-         "foo":"string"
-        },
-     "168":
-        {
-         "foo":"string"
-        }
-    },
- "tiles":
-    {
-     "123":
+ "tiles":[
         {
          "animation":[
                 {
@@ -57,9 +34,383 @@
                 {
                  "duration":100,
                  "tileid":165
+                }],
+         "id":123
+        }, 
+        {
+         "id":128,
+         "properties":[
+                {
+                 "name":"foo",
+                 "type":"string",
+                 "value":"bar"
                 }]
-        }
-    },
+        }, 
+        {
+         "id":168,
+         "properties":[
+                {
+                 "name":"foo",
+                 "type":"string",
+                 "value":"bar"
+                }]
+        }],
  "tilewidth":16,
- "type":"tileset"
+ "type":"tileset",
+ "version":1.2,
+ "wangsets":[
+        {
+         "cornercolors":[
+                {
+                 "color":"#fffa67",
+                 "name":"Beach",
+                 "probability":1,
+                 "tile":-1
+                }, 
+                {
+                 "color":"#00a600",
+                 "name":"Grass",
+                 "probability":1,
+                 "tile":-1
+                }, 
+                {
+                 "color":"#0000ff",
+                 "name":"Water",
+                 "probability":1,
+                 "tile":-1
+                }],
+         "edgecolors":[],
+         "name":"Ground",
+         "tile":-1,
+         "wangtiles":[
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":0,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 2, 0, 2, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":120,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 1, 0, 2, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":121,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 1, 0, 1, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":122,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 2, 0, 1, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":160,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 1, 0, 2, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":161,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 1, 0, 1, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":162,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 2, 0, 1, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":200,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 2, 0, 2, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":201,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 2, 0, 2, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":202,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 2, 0, 2, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":240,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 2, 0, 0, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":241,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 1, 0, 2, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":242,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 3, 0, 2, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":243,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 3, 0, 3, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":244,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 2, 0, 3, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":255,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 3, 0, 1, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":256,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 3, 0, 3, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":257,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 1, 0, 3, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":280,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 1, 0, 1, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":281,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 1, 0, 0, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":282,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 3, 0, 2, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":283,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 3, 0, 3, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":284,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 2, 0, 3, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":295,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 3, 0, 1, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":297,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 1, 0, 3, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":322,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 2, 0, 2, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":323,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 2, 0, 2, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":324,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 2, 0, 2, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":335,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 1, 0, 1, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":336,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 1, 0, 1, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":337,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 1, 0, 1, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":362,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 2, 0, 3, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":363,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 3, 0, 2, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":375,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 1, 0, 3, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":376,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 3, 0, 1, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":402,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 3, 0, 3, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":403,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 3, 0, 3, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":415,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 3, 0, 3, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":416,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 3, 0, 3, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":528,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 2, 0, 3, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":529,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 3, 0, 2, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":530,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 2, 0, 1, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":531,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 1, 0, 2, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":568,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 1, 0, 3, 0, 3]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":569,
+                 "vflip":false,
+                 "wangid":[0, 3, 0, 3, 0, 1, 0, 2]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":570,
+                 "vflip":false,
+                 "wangid":[0, 2, 0, 3, 0, 3, 0, 1]
+                }, 
+                {
+                 "dflip":false,
+                 "hflip":false,
+                 "tileid":571,
+                 "vflip":false,
+                 "wangid":[0, 1, 0, 3, 0, 3, 0, 2]
+                }]
+        }]
 }

--- a/TiledLib.Tests/Data/External_tileset.tsx
+++ b/TiledLib.Tests/Data/External_tileset.tsx
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset version="1.2" tiledversion="1.2.2" name="External_Tileset" tilewidth="16" tileheight="16" tilecount="1440" columns="40">
+ <image source="Overworld.png" width="640" height="576"/>
+ <tile id="123">
+  <animation>
+   <frame tileid="123" duration="100"/>
+   <frame tileid="124" duration="100"/>
+   <frame tileid="125" duration="100"/>
+   <frame tileid="163" duration="100"/>
+   <frame tileid="164" duration="100"/>
+   <frame tileid="165" duration="100"/>
+  </animation>
+ </tile>
+ <tile id="128">
+  <properties>
+   <property name="foo" value="bar"/>
+  </properties>
+ </tile>
+ <tile id="168">
+  <properties>
+   <property name="foo" value="bar"/>
+  </properties>
+ </tile>
+ <wangsets>
+  <wangset name="Ground" tile="-1">
+   <wangcornercolor name="Beach" color="#fffa67" tile="-1" probability="1"/>
+   <wangcornercolor name="Grass" color="#00a600" tile="-1" probability="1"/>
+   <wangcornercolor name="Water" color="#0000ff" tile="-1" probability="1"/>
+   <wangtile tileid="0" wangid="0x20202020"/>
+   <wangtile tileid="120" wangid="0x20201020"/>
+   <wangtile tileid="121" wangid="0x20101020"/>
+   <wangtile tileid="122" wangid="0x20102020"/>
+   <wangtile tileid="160" wangid="0x20201010"/>
+   <wangtile tileid="161" wangid="0x10101010"/>
+   <wangtile tileid="162" wangid="0x10102020"/>
+   <wangtile tileid="200" wangid="0x20202010"/>
+   <wangtile tileid="201" wangid="0x10202010"/>
+   <wangtile tileid="202" wangid="0x10202020"/>
+   <wangtile tileid="240" wangid="0x10002010"/>
+   <wangtile tileid="241" wangid="0x10201010"/>
+   <wangtile tileid="242" wangid="0x20203020"/>
+   <wangtile tileid="243" wangid="0x20303020"/>
+   <wangtile tileid="244" wangid="0x20302020"/>
+   <wangtile tileid="255" wangid="0x10103010"/>
+   <wangtile tileid="256" wangid="0x10303010"/>
+   <wangtile tileid="257" wangid="0x10301010"/>
+   <wangtile tileid="280" wangid="0x10101020"/>
+   <wangtile tileid="281" wangid="0x20001010"/>
+   <wangtile tileid="282" wangid="0x20203030"/>
+   <wangtile tileid="283" wangid="0x30303030"/>
+   <wangtile tileid="284" wangid="0x30302020"/>
+   <wangtile tileid="295" wangid="0x10103030"/>
+   <wangtile tileid="297" wangid="0x30301010"/>
+   <wangtile tileid="322" wangid="0x20202030"/>
+   <wangtile tileid="323" wangid="0x30202030"/>
+   <wangtile tileid="324" wangid="0x30202020"/>
+   <wangtile tileid="335" wangid="0x10101030"/>
+   <wangtile tileid="336" wangid="0x30101030"/>
+   <wangtile tileid="337" wangid="0x30101010"/>
+   <wangtile tileid="362" wangid="0x30302030"/>
+   <wangtile tileid="363" wangid="0x30203030"/>
+   <wangtile tileid="375" wangid="0x30301030"/>
+   <wangtile tileid="376" wangid="0x30103030"/>
+   <wangtile tileid="402" wangid="0x30303020"/>
+   <wangtile tileid="403" wangid="0x20303030"/>
+   <wangtile tileid="415" wangid="0x30303010"/>
+   <wangtile tileid="416" wangid="0x10303030"/>
+   <wangtile tileid="528" wangid="0x30302010"/>
+   <wangtile tileid="529" wangid="0x10203030"/>
+   <wangtile tileid="530" wangid="0x30102030"/>
+   <wangtile tileid="531" wangid="0x30201030"/>
+   <wangtile tileid="568" wangid="0x30301020"/>
+   <wangtile tileid="569" wangid="0x20103030"/>
+   <wangtile tileid="570" wangid="0x10303020"/>
+   <wangtile tileid="571" wangid="0x20303010"/>
+  </wangset>
+ </wangsets>
+</tileset>

--- a/TiledLib.Tests/External_tileset_TmxTests.cs
+++ b/TiledLib.Tests/External_tileset_TmxTests.cs
@@ -33,5 +33,23 @@ namespace TiledLib.Tests
             var result = JsonConvert.DeserializeObject<Map>(mapData);
             Assert.IsNotNull(result);
         }
+
+        [DataTestMethod]
+        [DataRow("Data/External_tileset.json")]
+        [DataRow("Data/External_tileset.tsx")]
+        public void TestWangParsing(string file)
+        {
+            using (var f = new FileStream(file, FileMode.Open))
+            {
+                var tileset = Tileset.FromStream(f);
+                Assert.AreEqual(1, tileset.WangSets.Length);
+                var set = tileset.WangSets[0];
+                Assert.AreEqual(3, set.CornerColors.Length);
+                Assert.IsTrue(set.WangTiles.Length > 0);
+                var grass = set.WangTiles.Single(x => x.TileId == 0);
+                grass.CompressedWangId = grass.CompressedWangId;
+                CollectionAssert.AreEqual(new[] { 0, 2, 0, 2, 0, 2, 0, 2 }, grass.WangId);
+            }
+        }
     }
 }

--- a/TiledLib.Tests/WriteTests.cs
+++ b/TiledLib.Tests/WriteTests.cs
@@ -14,7 +14,7 @@ namespace TiledLib.Tests
         [DataRow("Data/External_tileset_map.tmx")]
         [DataRow("Data/External_tileset_map_base64.tmx")]
         [DataRow("Data/Hexagonal_tileset.tmx")]
-        public void TestWriting(string file)
+        public void TestTmxWriting(string file)
         {
             using (var original = new MemoryStream())
             {
@@ -50,5 +50,40 @@ namespace TiledLib.Tests
                 }
             }
         }
+
+        [DataTestMethod]
+        [DataRow("Data/External_tileset.tsx")]
+        public void TestTsxWriting(string file)
+        {
+            using (var original = new MemoryStream())
+            {
+                using (var tilesetStream = File.OpenRead(file))
+                {
+                    tilesetStream.CopyTo(original);
+                    original.Seek(0, SeekOrigin.Begin);
+                }
+
+                var tileset = Tileset.FromStream(original);
+                original.Seek(0, SeekOrigin.Begin);
+                using (var output = new MemoryStream())
+                {
+                    using (var writer = new StreamWriter(output, Encoding.UTF8, 1024, true))
+                    {
+                        new XmlSerializer(typeof(Tileset)).Serialize(writer, tileset);
+                    }
+
+                    var expected = Encoding.UTF8.GetString(original.ToArray());
+                    var result = Encoding.UTF8.GetString(output.ToArray()).Substring(1); //Skip BOM
+
+                    while (expected.Length > 0 && result.Length > 0 && char.ToLowerInvariant(expected[0]) == char.ToLowerInvariant(result[0]))
+                    {
+                        expected = expected.Substring(1).Trim();
+                        result = result.Substring(1).Trim();
+                    }
+                    Assert.AreEqual(expected, result, ignoreCase: true);
+                }
+            }
+        }
+
     }
 }

--- a/TiledLib/ExternalTileset.cs
+++ b/TiledLib/ExternalTileset.cs
@@ -37,6 +37,8 @@ namespace TiledLib
 
         public TileOffset TileOffset => Tileset.TileOffset;
 
+        public WangSet[] WangSets => Tileset.WangSets;
+
         public Tile this[int gid] => Tileset[gid];
         public string this[int gid, string property] => Tileset[gid, property];
 

--- a/TiledLib/ITileset.cs
+++ b/TiledLib/ITileset.cs
@@ -28,5 +28,7 @@ namespace TiledLib
         string TransparentColor { get; }
 
         TileOffset TileOffset { get; }
+
+        WangSet[] WangSets { get; }
     }
 }

--- a/TiledLib/Map.cs
+++ b/TiledLib/Map.cs
@@ -99,7 +99,6 @@ namespace TiledLib
         {
             writer.WriteMapAttributes(this);
             writer.WriteMapElements(this);
-            //HACK: throw new NotImplementedException();
         }
     }
 }

--- a/TiledLib/Tileset.cs
+++ b/TiledLib/Tileset.cs
@@ -10,6 +10,10 @@ namespace TiledLib
     [XmlRoot("tileset")]
     public class Tileset : ITileset, IXmlSerializable
     {
+        public string Version { get; set; }
+
+        public string TiledVersion { get; set; }
+
         public string Name { get; set; }
 
         public int FirstGid { get; set; }
@@ -86,7 +90,7 @@ namespace TiledLib
 
         public static Tileset FromStream(System.IO.Stream stream)
         {
-            using (var reader = new System.IO.StreamReader(stream))
+            using (var reader = new System.IO.StreamReader(stream, System.Text.Encoding.UTF8, true, 1024, true))
             {
                 if (Utils.ContainsJson(reader))
                     return (Tileset)Utils.JsonSerializer.Deserialize(reader, typeof(Tileset));
@@ -104,7 +108,7 @@ namespace TiledLib
 
         public void WriteXml(XmlWriter writer)
         {
-            throw new NotImplementedException();
+            writer.WriteTileset(this, true);
         }
     }
 }

--- a/TiledLib/Tileset.cs
+++ b/TiledLib/Tileset.cs
@@ -36,6 +36,8 @@ namespace TiledLib
         [JsonProperty("tileproperties")]
         public Dictionary<int, Dictionary<string, string>> TileProperties { get; } = new Dictionary<int, Dictionary<string, string>>();
 
+        public WangSet[] WangSets { get; set; }
+
         public string this[int gid, string property]
         {
             get

--- a/TiledLib/TmxMap.cs
+++ b/TiledLib/TmxMap.cs
@@ -109,57 +109,10 @@ namespace TiledLib
                         writer.WriteEndElement();
                         break;
                     case Tileset ts:
+                        if (ts.FirstGid < 1)
+                            throw new ArgumentOutOfRangeException(nameof(Tileset.FirstGid));
                         writer.WriteStartElement("tileset");
-                        {
-                            if (ts.FirstGid < 1)
-                                throw new ArgumentOutOfRangeException(nameof(Tileset.FirstGid));
-                            writer.WriteAttribute("firstgid", ts.FirstGid);
-                            if (ts.Name != null)
-                                writer.WriteAttribute("name", ts.Name);
-
-                            writer.WriteAttribute("tilewidth", ts.TileWidth);
-                            writer.WriteAttribute("tileheight", ts.TileHeight);
-                            if (ts.Spacing != 0)
-                                writer.WriteAttribute("spacing", ts.Spacing);
-                            if (ts.TileCount != 0)
-                                writer.WriteAttribute("tilecount", ts.TileCount);
-                            if (ts.Columns != 0)
-                                writer.WriteAttribute("columns", ts.Columns);
-
-                            if(ts.TileOffset != null)
-                            {
-                                writer.WriteStartElement("tileoffset");
-                                writer.WriteAttribute("x", ts.TileOffset.X);
-                                writer.WriteAttribute("y", ts.TileOffset.Y);
-                                writer.WriteEndElement();
-                            }
-
-                            writer.WriteStartElement("image");
-                            {
-                                writer.WriteAttribute("source", ts.ImagePath);
-                                if (ts.ImageWidth != 0)
-                                    writer.WriteAttribute("width", ts.ImageWidth);
-                                if (ts.ImageHeight != 0)
-                                    writer.WriteAttribute("height", ts.ImageHeight);
-                            }
-                            writer.WriteEndElement();
-
-                            writer.WriteProperties(ts.Properties);
-
-                            foreach (var t in ts.TileProperties)
-                            {
-                                writer.WriteStartElement("tile");
-                                {
-                                    writer.WriteAttribute("id", t.Key);
-
-                                    writer.WriteProperties(t.Value);
-                                    if (ts.TileAnimations != null)
-                                        if (ts.TileAnimations.TryGetValue(t.Key, out var anim) && anim?.Length > 0)
-                                            writer.WriteAnimation(anim);
-                                }
-                                writer.WriteEndElement();
-                            }
-                        }
+                        writer.WriteTileset(ts, false);
                         writer.WriteEndElement();
                         break;
                     default:
@@ -215,19 +168,6 @@ namespace TiledLib
 
             //map.Tilesets = tilesets.ToArray();
             //map.Layers = layers.ToArray();
-        }
-
-        static void WriteAnimation(this XmlWriter writer, Frame[] animation)
-        {
-            writer.WriteStartElement("animation");
-            foreach (var frame in animation)
-            {
-                writer.WriteStartElement("frame");
-                writer.WriteAttribute("tileid", frame.TileId);
-                writer.WriteAttribute("duration", frame.Duration_ms);
-                writer.WriteEndElement();
-            }
-            writer.WriteEndElement();
-        }        
+        }      
     }
 }

--- a/TiledLib/TmxMisc.cs
+++ b/TiledLib/TmxMisc.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
+using System.Xml.Serialization;
 using TiledLib.Layer;
 
 namespace TiledLib
@@ -64,6 +65,11 @@ namespace TiledLib
                         break;
                     case "tile":
                         reader.ReadTile(ts.TileProperties, ts.TileAnimations);
+                        break;
+                    case "wangsets":
+                        reader.ReadStartElement();
+                        ts.WangSets = reader.ReadArray<WangSet>("wangset");
+                        reader.ReadEndElement();
                         break;
                     default:
                         reader.Skip();
@@ -287,5 +293,18 @@ namespace TiledLib
 
         public static void WriteAttribute(this XmlWriter writer, string localName, string value)
             => writer.WriteAttributeString(localName, value);
+
+        public static T[] ReadArray<T>(this XmlReader reader, string elementName)
+        {
+            var s = new XmlSerializer(typeof(T), new XmlRootAttribute(elementName));
+            var results = new List<T>();
+            while(reader.IsStartElement())
+            {
+                results.Add((T)s.Deserialize(reader));
+            }
+            return results.ToArray();
+        }
+
+
     }
 }

--- a/TiledLib/TmxMisc.cs
+++ b/TiledLib/TmxMisc.cs
@@ -33,6 +33,9 @@ namespace TiledLib
             if (!reader.IsStartElement("tileset"))
                 throw new XmlException(reader.Name);
 
+            ts.Version = reader["version"];
+            ts.TiledVersion = reader["tiledversion"];
+
             if (reader["firstgid"] != null)
                 ts.FirstGid = int.Parse(reader["firstgid"]);
 
@@ -80,6 +83,73 @@ namespace TiledLib
                 reader.ReadEndElement();
             else
                 throw new XmlException(reader.Name);
+        }
+
+        public static void WriteTileset(this XmlWriter writer, Tileset ts, bool isExternal)
+        {
+            if (isExternal)
+            {
+                if(ts.Version != null)
+                    writer.WriteAttribute("version", ts.Version);
+                if(ts.TiledVersion != null)
+                    writer.WriteAttribute("tiledversion", ts.TiledVersion);
+            }
+            else
+            {
+                writer.WriteAttribute("firstgid", ts.FirstGid);
+            }
+            if (ts.Name != null)
+                writer.WriteAttribute("name", ts.Name);
+
+            writer.WriteAttribute("tilewidth", ts.TileWidth);
+            writer.WriteAttribute("tileheight", ts.TileHeight);
+            if (ts.Spacing != 0)
+                writer.WriteAttribute("spacing", ts.Spacing);
+            if (ts.TileCount != 0)
+                writer.WriteAttribute("tilecount", ts.TileCount);
+            if (ts.Columns != 0)
+                writer.WriteAttribute("columns", ts.Columns);
+
+            if (ts.TileOffset != null)
+            {
+                writer.WriteStartElement("tileoffset");
+                writer.WriteAttribute("x", ts.TileOffset.X);
+                writer.WriteAttribute("y", ts.TileOffset.Y);
+                writer.WriteEndElement();
+            }
+
+            writer.WriteStartElement("image");
+            {
+                writer.WriteAttribute("source", ts.ImagePath);
+                if (ts.ImageWidth != 0)
+                    writer.WriteAttribute("width", ts.ImageWidth);
+                if (ts.ImageHeight != 0)
+                    writer.WriteAttribute("height", ts.ImageHeight);
+            }
+            writer.WriteEndElement();
+
+            writer.WriteProperties(ts.Properties);
+
+            foreach (var t in ts.TileProperties)
+            {
+                writer.WriteStartElement("tile");
+                {
+                    writer.WriteAttribute("id", t.Key);
+
+                    writer.WriteProperties(t.Value);
+                    if (ts.TileAnimations != null)
+                        if (ts.TileAnimations.TryGetValue(t.Key, out var anim) && anim?.Length > 0)
+                            writer.WriteAnimation(anim);
+                }
+                writer.WriteEndElement();
+            }
+
+            if (ts.WangSets != null)
+            {
+                writer.WriteStartElement("wangsets");
+                writer.WriteArray("wangset", ts.WangSets);
+                writer.WriteEndElement();
+            }
         }
 
         static void ReadTile(this XmlReader reader, Dictionary<int, Dictionary<string, string>> tileProperties, Dictionary<int, Frame[]> tileAnimations)
@@ -132,6 +202,18 @@ namespace TiledLib
                 .ToArray();
         }
 
+        static void WriteAnimation(this XmlWriter writer, Frame[] animation)
+        {
+            writer.WriteStartElement("animation");
+            foreach (var frame in animation)
+            {
+                writer.WriteStartElement("frame");
+                writer.WriteAttribute("tileid", frame.TileId);
+                writer.WriteAttribute("duration", frame.Duration_ms);
+                writer.WriteEndElement();
+            }
+            writer.WriteEndElement();
+        }
 
         static int[] ReadCSV(this XmlReader reader, int size)
         {
@@ -298,11 +380,22 @@ namespace TiledLib
         {
             var s = new XmlSerializer(typeof(T), new XmlRootAttribute(elementName));
             var results = new List<T>();
-            while(reader.IsStartElement())
+            while (reader.IsStartElement())
             {
                 results.Add((T)s.Deserialize(reader));
             }
             return results.ToArray();
+        }
+
+        public static void WriteArray<T>(this XmlWriter writer, string elementName, T[] values)
+        {
+            var s = new XmlSerializer(typeof(T), new XmlRootAttribute(elementName));
+            XmlSerializerNamespaces ns = new XmlSerializerNamespaces();
+            ns.Add("", "");
+            foreach (var value in values)
+            {
+                s.Serialize(writer, value, ns);
+            }
         }
 
 

--- a/TiledLib/WangSet.cs
+++ b/TiledLib/WangSet.cs
@@ -1,0 +1,83 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Xml.Serialization;
+
+namespace TiledLib
+{
+    public class WangColor
+    {
+        [XmlAttribute("color")]
+        public string Color { get; set; }
+
+        [XmlAttribute("name")]
+        public string Name { get; set; }
+
+        [XmlAttribute("probability")]
+        public double Probability { get; set; }
+
+        [XmlAttribute("tile")]
+        public int Tile { get; set; }
+    }
+
+    public class WangTile
+    {
+        [XmlAttribute("dflip")]
+        public bool DFlip { get; set; }
+
+        [XmlAttribute("hflip")]
+        public bool HFlip { get; set; }
+
+        [XmlAttribute("vflip")]
+        public bool VFlip { get; set; }
+
+        [XmlAttribute("tileid")]
+        public int TileId { get; set; }
+
+        [XmlIgnore]
+        public int[] WangId { get; set; }
+
+        [XmlAttribute("wangid")]
+        [JsonIgnore]
+        public string CompressedWangId
+        {
+            get
+            {
+                var c = 0;
+                for(var i=7;i>=0;i--)
+                {
+                    c = (c << 4) + WangId[i];
+                }
+                return "0x" + Convert.ToString(c, 16);
+            }
+            set
+            {
+                var c = Convert.ToInt32(value, 16);
+                var r = new[] { 0, 0, 0, 0, 0, 0, 0, 0 };
+                for(var i=0;i<8;i++)
+                {
+                    r[i] = c & 0xF;
+                    c = c >> 4;
+                }
+                WangId = r;
+            }
+        }
+    }
+
+    public class WangSet
+    {
+        [XmlElement("wangcornercolor")]
+        public WangColor[] CornerColors { get; set; }
+
+        [XmlElement("wangedgecolor")]
+        public WangColor[] EdgeColors { get; set; }
+
+        [XmlAttribute("name")]
+        public string Name { get; set; }
+
+        [XmlAttribute("tile")]
+        public int Tile { get; set; }
+
+        [XmlElement("wangtile")]
+        public WangTile[] WangTiles { get; set; }
+    }
+}

--- a/TiledLib/WangSet.cs
+++ b/TiledLib/WangSet.cs
@@ -1,32 +1,36 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.ComponentModel;
 using System.Xml.Serialization;
 
 namespace TiledLib
 {
     public class WangColor
     {
-        [XmlAttribute("color")]
-        public string Color { get; set; }
-
         [XmlAttribute("name")]
         public string Name { get; set; }
 
-        [XmlAttribute("probability")]
-        public double Probability { get; set; }
+        [XmlAttribute("color")]
+        public string Color { get; set; }
 
         [XmlAttribute("tile")]
         public int Tile { get; set; }
+
+        [XmlAttribute("probability")]
+        public double Probability { get; set; }
     }
 
     public class WangTile
     {
+        [DefaultValue(false)]
         [XmlAttribute("dflip")]
         public bool DFlip { get; set; }
 
+        [DefaultValue(false)]
         [XmlAttribute("hflip")]
         public bool HFlip { get; set; }
 
+        [DefaultValue(false)]
         [XmlAttribute("vflip")]
         public bool VFlip { get; set; }
 


### PR DESCRIPTION
I wanted to play around with this feature, so I added it to your library.

I've departed a bit from your conventions. Rather than manually loading WangSet, i'm using XmlSerializer. This is a bit less verbose, imho, and in this case the extra flexibility isn't needed - you can see I successfully round trip a `.tsx` file. Also, chose to match the JSON format rather than the xml one, where they differ.

I also moved some code from TmxMap to TmxMisc - imho it makes more sense to keep reading and writing code in parallel. The upshot of this is you can now write .tsx files. I haven't made an official public API for doing so though.